### PR TITLE
Chore: Misc app cleanup.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev": "eval $(yarn -s env) && next dev",
     "clean": "rm -rf .next",
     "build": "eval $(yarn -s env) && next build",
-    "start": "eval $(yarn -s env) && node server/index.js",
+    "start": "eval $(yarn -s env) && node server/blog.js",
     "env": "echo export STAGE=${STAGE:-localdev}; echo export BASE_PATH=${BASE_PATH:-/blog}; echo export SERVICE_NAME=nextjs-serverless; echo export AWS_REGION=${AWS_REGION:-us-east-1}; echo export AWS_XRAY_CONTEXT_MISSING=LOG_ERROR",
     "cf:_params": "eval $(yarn -s env) && echo --parameters ParameterKey=Stage,ParameterValue=${STAGE} ParameterKey=ServiceName,ParameterValue=${SERVICE_NAME}",
     "cf:bootstrap:_stack": "eval $(yarn -s env) && echo --region ${AWS_REGION} --stack-name cf-${SERVICE_NAME}-${STAGE}-bootstrap",

--- a/server/blog.js
+++ b/server/blog.js
@@ -3,6 +3,7 @@
 const { parse } = require("url");
 const express = require("express");
 const next = require("next");
+const { addRootHandlers } = require("./root");
 
 const DEFAULT_PORT = 4000;
 const PORT = parseInt(process.env.SERVER_PORT || DEFAULT_PORT, 10);
@@ -10,7 +11,7 @@ const HOST = process.env.SERVER_HOST || "0.0.0.0";
 const JSON_INDENT = 2;
 
 // Create the server app.
-const getApp = async () => {
+const getApp = async ({ extraHandlers } = {}) => {
   // Set up Next.js server.
   // eslint-disable-next-line callback-return
   const nextApp = next({ dev: false });
@@ -22,6 +23,11 @@ const getApp = async () => {
 
   // Development tweaks.
   app.set("json spaces", JSON_INDENT);
+
+  // Add in extra handlers
+  if (extraHandlers) {
+    extraHandlers(app);
+  }
 
   // Page handlers,
   app.use((req, res) => {
@@ -51,7 +57,9 @@ module.exports.handler = async (event, context) => {
 // DOCKER/DEV/ANYTHING: Start the server directly.
 if (require.main === module) {
   (async () => {
-    const server = (await getApp()).listen({
+    const server = (await getApp({
+      extraHandlers: addRootHandlers
+    })).listen({
       port: PORT,
       host: HOST
     }, () => {

--- a/server/root.js
+++ b/server/root.js
@@ -1,0 +1,63 @@
+"use strict";
+
+const express = require("express");
+
+const DEFAULT_PORT = 4000;
+const PORT = parseInt(process.env.SERVER_PORT || DEFAULT_PORT, 10);
+const HOST = process.env.SERVER_HOST || "0.0.0.0";
+const JSON_INDENT = 2;
+
+// Export root handlers so we can add those to Node.js localdev.
+const addRootHandlers = module.exports.addRootHandlers = (app) => {
+  // Page handlers,
+  app.use(express.static("public"));
+  app.get("/", (req, res) => res.json({
+    msg: "Root handler. Check out /blog for more!"
+  }));
+
+  return app;
+};
+
+// Create the server app.
+const getApp = async () => {
+  // Stage, base path stuff.
+  const app = express();
+
+  // Development tweaks.
+  app.set("json spaces", JSON_INDENT);
+
+  addRootHandlers(app);
+
+  return app;
+};
+
+// LAMBDA: Export handler for lambda use.
+let handler;
+module.exports.handler = async (event, context) => {
+  // Lazy require `serverless-http` to allow non-Lambda targets to omit.
+  // eslint-disable-next-line global-require
+  handler = handler || require("serverless-http")(
+    await getApp(),
+    // TODO(STATIC): Again, shouldn't be serving images from the Lambda :)
+    {
+      binary: ["image/*"]
+    }
+  );
+
+  return handler(event, context);
+};
+
+// DOCKER/DEV/ANYTHING: Start the server directly.
+if (require.main === module) {
+  (async () => {
+    const server = (await getApp()).listen({
+      port: PORT,
+      host: HOST
+    }, () => {
+      const { address, port } = server.address();
+
+      // eslint-disable-next-line no-console
+      console.log(`Server started at http://${address}:${port}`);
+    });
+  })();
+}

--- a/serverless.yml
+++ b/serverless.yml
@@ -54,8 +54,9 @@ custom:
         resolutions:
           # TODO(SERVER): Lots more resolutions needed!
 
-          # Our server does lazy requires of pages.
-          "./server/index.js": []
+          # Our servers do lazy requires of pages.
+          "./server/blog.js": []
+          "./server/root.js": []
 
           # [169:22]: require(`./transformers/${Transformer}.js`)
           "@ampproject/toolbox-optimizer/lib/DomTransformer.js": []
@@ -112,7 +113,7 @@ provider:
 functions:
   # SCENARIO - base: The simplest, vanilla Serverless app.
   blog:
-    handler: server/index.handler
+    handler: server/blog.handler
     environment:
       BASE_PATH: /blog
     events: # Use a generic proxy to allow Express app to route.
@@ -136,6 +137,18 @@ functions:
         - ".next/BUILD_ID"
         - ".next/*.json"
         - ".next/server/**"
-        # TODO(STATIC): Add a note about this.
+        # TODO(STATIC): Should be served outside Lambda in real production.
         - ".next/static/**"
+
+  # TODO(STATIC): Simple static server for root assets.
+  root:
+    handler: server/root.handler
+    environment:
+      BASE_PATH: /
+    events: # Use a generic proxy to allow Express app to route.
+      - http: ANY /
+      - http: 'ANY /{proxy+}'
+    package:
+      include:
+        # TODO(STATIC): Should be served outside Lambda in real production.
         - "public/**"

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -6,7 +6,7 @@ import Link from "next/link";
 
 const name = "Next.js on AWS Lambda";
 export const siteTitle = "Next.js on AWS Lambda";
-const logoSrc = `${process.env.BASE_PATH}/images/formidable-logo.png`;
+const logoSrc = "/images/formidable-logo.png";
 // eslint-disable-next-line max-len
 const ogImgSrc = `https://og-image.now.sh/${encodeURI(siteTitle)}.png?theme=light&md=1&fontSize=100px&images=https%3A%2F%2Fassets.vercel.com%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fnextjs-black-logo.svg`;
 
@@ -14,7 +14,6 @@ export default function Layout({ children, home }) {
   return (
     <div className={styles.container}>
       <Head>
-        {/* TODO: Favicon will need separately asset handling to be at root slot. */}
         <link rel="icon" href="/favicon.ico" />
         <meta
           name="description"

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -7,6 +7,8 @@ import Link from "next/link";
 const name = "Next.js on AWS Lambda";
 export const siteTitle = "Next.js on AWS Lambda";
 const logoSrc = `${process.env.BASE_PATH}/images/formidable-logo.png`;
+// eslint-disable-next-line max-len
+const ogImgSrc = `https://og-image.now.sh/${encodeURI(siteTitle)}.png?theme=light&md=1&fontSize=100px&images=https%3A%2F%2Fassets.vercel.com%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fnextjs-black-logo.svg`;
 
 export default function Layout({ children, home }) {
   return (
@@ -17,6 +19,10 @@ export default function Layout({ children, home }) {
         <meta
           name="description"
           content="A demonstration blog for deploying Next.js on Lambda"
+        />
+        <meta
+          property="og:image"
+          content={ogImgSrc}
         />
         <meta name="og:title" content={siteTitle} />
         <meta name="twitter:card" content="summary_large_image" />


### PR DESCRIPTION
Fixes #10 

Work:

- Add a root lambda to statically server `public` so we get `favicon.ico` and `/images` serves from root removing need for `process.env.BASE_PATH` hack in app source.
- Add OG image

Currently deployed to: https://nextjs-sls-sandbox.formidable.dev/blog